### PR TITLE
Add comprehensive module documentation

### DIFF
--- a/docs/fmutil.md
+++ b/docs/fmutil.md
@@ -1,0 +1,105 @@
+# fmutil.F90 (Module: FMUtil)
+
+## Overview
+
+The `FMUtil` module is the primary public interface for the FMUTIL library. It consolidates various utilities, making them accessible to the end-user through a single `use FMUtil` statement. As described in the library's main documentation, FMUTIL provides miscellaneous utilities such as data structures (List, Vector), root-finding algorithms for polynomials and nonlinear equations, and search algorithms. By using `FMUtil`, users gain access to all these functionalities without needing to individually `use` each specific submodule.
+
+## Key Components
+
+The `FMUtil` module itself does not define new procedures or types. Instead, it makes entities from other modules within the FMUTIL library publicly available. When you `use FMUtil`, you are primarily gaining access to the public entities of the following modules:
+
+*   `FMUTILBase`: Provides fundamental base types, parameters, or utility procedures that might be used by other modules in the library. (The exact public entities would be detailed in `fmutilbase.md`).
+*   `RootFinding`: Offers tools for finding roots of equations. This includes algorithms for polynomial roots (potentially using companion matrices, possibly with dependencies like Intel MKL) and roots of nonlinear equations (e.g., Brent's algorithm).
+*   `Search`: Contains algorithms for searching within data structures, such as binary search for sorted arrays.
+*   `Vectors`: Provides the `Vector` dynamic array data structure (similar to C++ STL Vector), which requires users to define a custom element type extending `VecElem`. (Detailed in `vector.md`).
+*   `Lists`: Provides the `List` dynamic list data structure (similar to Python List), capable of storing items of different types (`class(*)`). (Detailed in `list.md`).
+
+## Important Variables/Constants
+
+The `fmutil.F90` file itself does not define any public variables or constants. Any such entities would be part of the modules it re-exports (e.g., `FMUTILBase` might define some).
+
+## Usage Examples
+
+Using `FMUtil` simplifies access to the library's data structures and algorithms. Here's how you might use it to work with a `List` or `Vector` (these examples are conceptual and draw from the detailed examples in `list.md` and `vector.md`):
+
+```fortran
+program Test_With_FMUtil
+  use FMUtil ! This single 'use' statement provides access to List, Vector, VecElem, etc.
+
+  ! Example using List (adapted from list.md usage)
+  implicit none
+  type(List) :: my_generic_list
+  integer :: list_idx
+  real :: r_val = 3.14
+
+  list_idx = my_generic_list%PushBack(10)          ! Add an integer
+  list_idx = my_generic_list%PushBack(r_val)       ! Add a real
+  list_idx = my_generic_list%PushBack("hello")     ! Add a character string
+
+  print *, "My generic list size:", my_generic_list%Size()
+
+  ! Example using Vector (requires a custom element type definition)
+  ! First, define your custom element type and its assignment operator
+  ! (This would typically be in its own module, as shown in vector.md)
+  module MyCustomElements
+    use FMUtil ! VecElem is available via FMUtil
+    implicit none
+    private
+    public :: MyDataElement, assign_my_data_element ! Only export what's needed
+
+    type, extends(VecElem) :: MyDataElement
+      integer :: id
+      real :: value
+    contains
+      procedure :: AssignVecElem => assign_my_data_element
+    end type MyDataElement
+  contains
+    subroutine assign_my_data_element(lhs, rhs)
+      class(MyDataElement), intent(out) :: lhs
+      class(VecElem), intent(in) :: rhs
+      select type (rhs)
+      class is (MyDataElement)
+        lhs%id = rhs%id
+        lhs%value = rhs%value
+      end select
+    end subroutine assign_my_data_element
+  end module MyCustomElements
+
+  ! Now use the custom element with Vector
+  use MyCustomElements
+  type(Vector) :: my_data_vector
+  type(MyDataElement) :: data_item
+  integer :: vec_idx
+
+  ! Initialize vector (optional, if MoldElem is needed before first PushBack)
+  call my_data_vector%Init(MoldElem=MyDataElement(0, 0.0))
+
+  data_item%id = 1
+  data_item%value = 10.5
+  vec_idx = my_data_vector%PushBack(data_item)
+
+  data_item%id = 2
+  data_item%value = 20.8
+  vec_idx = my_data_vector%PushBack(data_item)
+
+  print *, "My data vector size:", my_data_vector%Size()
+
+  ! ... further operations on my_generic_list and my_data_vector ...
+
+end program Test_With_FMUtil
+```
+For more detailed examples of how to use specific components like `Vector` (including defining `AssignVecElem` for custom types) or `List`, please refer to their respective documentation files (`vector.md`, `list.md`) and the extensive examples in the `fmutil.F90` source file comments.
+
+## Dependencies and Interactions
+
+The `FMUtil` module acts as a central aggregation point or facade for the FMUTIL library. Its primary role is to provide a convenient, single point of access to the functionalities offered by other modules.
+
+*   **Internal Dependencies:**
+    *   `FMUTILBase`: Relies on it for base definitions.
+    *   `RootFinding`: Relies on it to provide root-finding capabilities.
+    *   `Search`: Relies on it to provide search algorithms.
+    *   `Vectors`: Relies on it to provide the `Vector` data structure.
+    *   `Lists`: Relies on it to provide the `List` data structure.
+*   **External Libraries:**
+    *   None directly by `FMUtil` itself, but sub-modules like `RootFinding` might have dependencies (e.g., Intel MKL for polynomial root-finding, as mentioned in `fmutil.F90` comments).
+```

--- a/docs/fmutil_base.md
+++ b/docs/fmutil_base.md
@@ -1,0 +1,89 @@
+# fmutil_base.F90 (Module: FMUTILBase)
+
+## Overview
+
+The `FMUTILBase` module serves as a foundational component for the FMUTIL library. It provides basic objects, numerical precision parameters, and commonly used constants that are utilized by other internal modules within FMUTIL. Its main purpose is to establish a consistent set of definitions for floating-point precision and mathematical constants.
+
+## Key Components
+
+The `FMUTILBase` module primarily exports parameters (constants). It does not define any public procedures (functions/subroutines) or derived types/classes.
+
+### Functions/Subroutines
+
+*   Not applicable. This module does not export public procedures.
+
+### Types/Classes
+
+*   Not applicable. This module does not export public types or classes.
+
+## Important Variables/Constants
+
+This module defines several key public parameters for numerical precision and mathematical constants:
+
+*   `DP` (integer, parameter): Kind parameter for double precision floating-point numbers, typically corresponding to `real64` from `iso_fortran_env`.
+*   `QP` (integer, parameter): Kind parameter for quadruple precision floating-point numbers, typically corresponding to `real128` from `iso_fortran_env`. Useful for calculations requiring very high precision.
+*   `WP` (integer, parameter): Default "Word Precision" kind parameter used throughout the FMUTIL library for real numbers. By default, it is set to `DP` (double precision).
+*   `EPS` (real(WP), parameter): The smallest positive real number of kind `WP` such that `1.0_WP + EPS > 1.0_WP`. This is effectively the machine epsilon for the default working precision.
+*   `INF` (real(WP), parameter): Represents infinity for real numbers of kind `WP`. It is defined as `huge(1.0_WP)`.
+*   `I3` (real(WP), dimension(3,3), parameter): A 3x3 identity matrix with elements of kind `WP`.
+*   `I6` (real(WP), dimension(6,6), parameter): A 6x6 identity matrix with elements of kind `WP`.
+
+## Usage Examples
+
+Here's how another module or a user's program might utilize the constants defined in `FMUTILBase`:
+
+```fortran
+module MyCalculationModule
+  ! Use specific constants from FMUTILBase
+  use FMUTILBase, only: WP, INF, EPS, DP
+  implicit none
+
+  real(WP) :: my_variable
+  real(DP) :: another_double_precision_var
+  logical :: is_too_small
+
+  public :: perform_calculation
+
+contains
+
+  subroutine perform_calculation(x, y)
+    real(WP), intent(in) :: x
+    real(WP), intent(out) :: y
+
+    if (abs(x) < EPS) then
+      is_too_small = .true.
+      y = INF ! Assign infinity if x is too small
+    else
+      is_too_small = .false.
+      y = 1.0_WP / x
+    end if
+
+    print *, "Is x too small? ", is_too_small
+    print *, "Calculated y: ", y
+
+    ! Using a different precision
+    another_double_precision_var = dble(x) ! Convert from WP if WP is not DP
+    print *, "x in double precision: ", another_double_precision_var
+
+  end subroutine perform_calculation
+
+end module MyCalculationModule
+
+program Test_FMUTILBase_Usage
+  use MyCalculationModule
+  ! FMUTILBase constants are used within MyCalculationModule
+  implicit none
+
+  call perform_calculation(1.0e-8_WP, 기본값_결과_변수)  ! WP will be taken from FMUTILBase via MyCalculationModule
+  call perform_calculation(1.0e-40_WP, 기본값_결과_변수_작음) ! Assuming WP is DP, this might be smaller than EPS
+
+end program Test_FMUTILBase_Usage
+```
+
+## Dependencies and Interactions
+
+*   **Internal Dependencies:**
+    *   None directly, as this is a base module. However, many other modules within the FMUTIL library (e.g., `Vectors`, `Lists`, `RootFinding`) depend on `FMUTILBase` for consistent precision kinds and fundamental constants.
+*   **External Libraries:**
+    *   `iso_fortran_env` (intrinsic module): Used to obtain standard kind parameters for `real64` (double precision) and `real128` (quadruple precision), which are then used to define `DP` and `QP`.
+```

--- a/docs/list.md
+++ b/docs/list.md
@@ -1,0 +1,82 @@
+# list.f90 (Module: Lists)
+
+## Overview
+
+The `Lists` module provides a dynamic list data structure, similar to Python lists. It allows for flexible collections of items (Fortran `class(*)`) where the size can change during runtime. The list is internally represented using a dynamically allocated array that grows as needed.
+
+## Key Components
+
+### Types/Classes
+
+*   `List`: This is the main public type representing the dynamic list. It encapsulates the data and provides methods to manipulate the list.
+    *   **Methods:**
+        *   `PushBack(newitem)`: Adds an item to the end of the list. Returns the index of the new item, or 0 on error.
+        *   `PopBack()`: Removes and returns the last item from the list.
+        *   `Item(Index)`: Returns a pointer to the item at the specified 1-based `Index`. The pointer is not associated if the index is invalid.
+        *   `Size()`: Returns the total number of items currently stored in the list.
+        *   `Insert(pos, NewItem)`: Inserts `NewItem` at the given 1-based `pos`. Items at and after `pos` are shifted.
+        *   `Erase(pos)`: Deletes the item at the given 1-based `pos`. Subsequent items are shifted.
+        *   `Clear()`: Removes all items from the list. The underlying memory is not deallocated immediately but can be by `ShrinkToFit`.
+        *   `ShrinkToFit()`: Deallocates unused memory so that the list's capacity matches its current size.
+        *   `Destroy()`: Finalizer procedure that frees all memory allocated by the list and its items. Called automatically when a `List` variable goes out of scope.
+        *   `assignment(=)`: Overloads the assignment operator to allow copying of one `List` to another, creating a deep copy of items.
+
+*   `ListItem`: This is a private type used internally by `List` to store individual items and their validity status. It holds a `class(*), pointer :: item` to the actual data. Users of the `List` type do not interact with `ListItem` directly.
+
+## Important Variables/Constants
+
+*   `DEFAULT_NEWSLOTSALLOCATED` (integer, parameter): Defines the default number of additional storage slots (5) to allocate when the list's capacity is exceeded and needs to grow.
+
+## Usage Examples
+
+```fortran
+program example_list_usage
+  use Lists
+  implicit none
+
+  type(List) :: my_list
+  integer :: item_value
+  integer :: list_size_val
+  class(*), pointer :: retrieved_item_ptr
+  integer, pointer :: retrieved_value_ptr
+
+  ! Add items to the list
+  call my_list%PushBack(10)
+  call my_list%PushBack(20)
+  call my_list%PushBack(30)
+
+  ! Get the size of the list
+  list_size_val = my_list%Size()
+  print *, "List size:", list_size_val ! Output: List size: 3
+
+  ! Retrieve an item (e.g., the second item)
+  retrieved_item_ptr => my_list%Item(2)
+  if (associated(retrieved_item_ptr)) then
+    select type (retrieved_item_ptr)
+    class is (integer)
+      retrieved_value_ptr => retrieved_item_ptr
+      print *, "Retrieved item (index 2):", retrieved_value_ptr ! Output: Retrieved item (index 2): 20
+    end select
+  else
+    print *, "Item not found or index out of bounds."
+  end if
+
+  ! Pop an item
+  call my_list%PopBack() ! Removes 30
+  print *, "List size after PopBack:", my_list%Size() ! Output: List size after PopBack: 2
+
+  ! Clear the list (items destroyed, memory kept until ShrinkToFit or Destroy)
+  call my_list%Clear()
+  print *, "List size after Clear:", my_list%Size() ! Output: List size after Clear: 0
+
+  ! Destroy is called automatically when my_list goes out of scope
+end program example_list_usage
+```
+
+## Dependencies and Interactions
+
+*   **Internal Dependencies:**
+    *   `FMUTILBase`: The `Lists` module uses `FMUTILBase`. The specific reason is not explicitly detailed in the comments of `list.f90` but `FMUTILBase` likely provides fundamental utilities or type definitions used by the `Lists` module.
+*   **External Libraries:**
+    *   None explicitly mentioned or used in `list.f90`.
+```

--- a/docs/rootfinding.md
+++ b/docs/rootfinding.md
@@ -1,0 +1,165 @@
+# rootfinding.f90 (Module: RootFinding)
+
+## Overview
+
+The `RootFinding` module provides numerical routines for finding roots of equations. It includes methods for computing all complex roots of a polynomial and for finding a single root of a general nonlinear function within a given interval.
+
+## Key Components
+
+### Abstract Interface `func`
+
+*   **Purpose:** This abstract interface defines the signature for a user-supplied function whose root is to be found by the `Root` subroutine.
+*   **Signature:**
+    ```fortran
+    abstract interface
+        pure function func(x) result(y)
+            import :: WP ! Uses the working precision from FMUTILBase
+            implicit none
+            real(WP), intent(in) :: x !< independent variable
+            real(WP) :: y             !< function result f(x)
+        end function func
+    end interface
+    ```
+    A user must provide a function that matches this interface (i.e., takes a `real(WP)` scalar `x` and returns a `real(WP)` scalar `y`) to be used with the `Root` subroutine.
+
+### Functions/Subroutines
+
+*   `PolyRoots(c, r, error, BalanceOn)`: Computes all complex roots of a given polynomial.
+    *   **Method:** Forms the companion matrix from the polynomial coefficients and then finds its eigenvalues using LAPACK routines (specifically `gebal` for balancing and `hseqr` for eigenvalue computation). This approach is similar to MATLAB's `roots` command.
+    *   **Parameters:**
+        *   `c` (complex(WP), dimension(1:), intent(in)): Coefficients of the polynomial `p(x) = c(1)*x^n + ... + c(n)*x + c(n+1)`. `c(1)` is the coefficient of the highest degree term.
+        *   `r` (complex(WP), dimension(:), allocatable, intent(out)): Allocatable array that will contain the computed complex roots of the polynomial.
+        *   `error` (integer, intent(out)): Error status.
+            *   `0`: Success.
+            *   `-1`: Input coefficients array `c` has length less than two (i.e., polynomial degree <= 0).
+            *   `-2`: All coefficients in `c` are zero.
+            *   `-3`: Companion matrix balancing (via `gebal`) failed.
+            *   `-4`: LAPACK routine (`hseqr`) failed to compute eigenvalues.
+        *   `BalanceOn` (logical, intent(in), optional): If `.TRUE.` (default), the companion matrix is balanced before eigenvalue computation. Set to `.FALSE.` if balancing is not desired, though this might affect accuracy for poorly-scaled matrices.
+
+*   `Root(a, b, ya, yb, tol, f, x, fx, niter, error)`: Computes a single root of a user-defined function `f` using Brent's algorithm.
+    *   **Method:** Implements Brent's method, which combines bisection, secant method, and inverse quadratic interpolation to find a root robustly and efficiently.
+    *   **Parameters:**
+        *   `a` (real(WP), intent(in)): Lower bound of the interval suspected to contain a root.
+        *   `b` (real(WP), intent(in)): Upper bound of the interval suspected to contain a root.
+        *   `ya` (real(WP), intent(in)): Value of the function at `a`, i.e., `f(a)`. (Note: The implementation recomputes `f(a)` and `f(b)` internally, so these might be considered for removal or as initial guesses).
+        *   `yb` (real(WP), intent(in)): Value of the function at `b`, i.e., `f(b)`. (Similar to `ya`).
+        *   `tol` (real(WP), intent(in)): Desired tolerance for the root `x`. The routine attempts to find `x` such that `abs(f(x))` is close to zero and the interval width is small.
+        *   `f` (procedure(func)): The user-supplied function whose root is sought. Must conform to the `func` abstract interface.
+        *   `x` (real(WP), intent(out)): The computed root.
+        *   `fx` (real(WP), intent(out)): The value of the function `f` at the computed root `x`.
+        *   `niter` (integer, intent(out)): Number of iterations performed by the algorithm.
+        *   `error` (integer, intent(out)): Error status.
+            *   `0`: Success, a root was found to the desired tolerance.
+            *   `1`: The root is not bracketed by the initial interval [`a`, `b`] (i.e., `f(a)` and `f(b)` have the same sign).
+            *   `2`: Maximum number of iterations (`MAX_ITERATIONS`) reached without achieving the desired tolerance.
+
+### Types/Classes
+*   Not applicable. This module does not define or export public types or classes.
+
+## Important Variables/Constants
+
+*   `MAX_ITERATIONS` (integer, parameter): Defines the maximum number of iterations allowed for the Brent's algorithm in the `Root` subroutine (value is 50). This prevents infinite loops in cases where convergence is too slow or fails.
+
+## Usage Examples
+
+### `PolyRoots` Example
+
+```fortran
+program Test_PolyRoots
+  use RootFinding
+  use FMUTILBase, only: WP ! For WP kind parameter
+  implicit none
+
+  ! Polynomial: x^3 - 6x^2 + 11x - 6 = 0
+  ! Roots should be 1, 2, 3
+  complex(WP), dimension(4) :: coeffs = [ (1.0_WP, 0.0_WP), & ! c(1) for x^3
+                                          (-6.0_WP, 0.0_WP), & ! c(2) for x^2
+                                          (11.0_WP, 0.0_WP), & ! c(3) for x^1
+                                          (-6.0_WP, 0.0_WP) ]  ! c(4) for x^0
+  complex(WP), dimension(:), allocatable :: roots_found
+  integer :: err_status
+  integer :: i
+
+  call PolyRoots(coeffs, roots_found, err_status)
+
+  if (err_status == 0) then
+    print *, "Roots found for P(x) = x^3 - 6x^2 + 11x - 6:"
+    do i = 1, size(roots_found)
+      print '(F8.4, SP, F8.4, "i")', real(roots_found(i)), aimag(roots_found(i))
+    end do
+  else
+    print *, "PolyRoots failed with error code: ", err_status
+  end if
+
+  if (allocated(roots_found)) deallocate(roots_found)
+
+end program Test_PolyRoots
+```
+
+### `Root` Example (Brent's Algorithm)
+
+```fortran
+module MyFunctions
+  use FMUTILBase, only: WP
+  implicit none
+
+  ! Define a function that matches the 'func' interface
+  pure function my_user_function(x_val) result(y_val)
+    real(WP), intent(in) :: x_val
+    real(WP) :: y_val
+    ! Example: f(x) = x^2 - 4
+    y_val = x_val**2 - 4.0_WP
+  end function my_user_function
+
+end module MyFunctions
+
+program Test_Root
+  use RootFinding
+  use FMUTILBase, only: WP
+  use MyFunctions, only: my_user_function ! Import our function
+  implicit none
+
+  real(WP) :: lower_bound, upper_bound
+  real(WP) :: val_at_lower, val_at_upper ! Not strictly needed as input as Root recomputes
+  real(WP) :: tolerance
+  real(WP) :: found_root, val_at_root
+  integer  :: iterations_taken, err_status
+
+  lower_bound = 0.0_WP
+  upper_bound = 5.0_WP
+  tolerance = 1.0e-6_WP
+
+  ! ya and yb are technically inputs but Root recalculates f(a) and f(b)
+  ! So, their input values here are not critical.
+  val_at_lower = my_user_function(lower_bound)
+  val_at_upper = my_user_function(upper_bound)
+
+  print *, "Seeking root for f(x) = x^2 - 4 in [", lower_bound, ",", upper_bound, "]"
+  call Root(lower_bound, upper_bound, val_at_lower, val_at_upper, &
+            tolerance, my_user_function,                           &
+            found_root, val_at_root, iterations_taken, err_status)
+
+  if (err_status == 0) then
+    print *, "Root found: ", found_root
+    print *, "f(root): ", val_at_root
+    print *, "Iterations: ", iterations_taken
+  elseif (err_status == 1) then
+    print *, "Root not bracketed in the given interval."
+    print *, "f(a)=", my_user_function(lower_bound), " f(b)=", my_user_function(upper_bound)
+  elseif (err_status == 2) then
+    print *, "Maximum iterations reached. Current approximation: ", found_root
+  else
+    print *, "Root finding failed with unknown error code: ", err_status
+  end if
+
+end program Test_Root
+```
+
+## Dependencies and Interactions
+
+*   **Internal Dependencies:**
+    *   `FMUTILBase`: Uses the `WP` kind parameter for defining the precision of real and complex numbers.
+*   **External Libraries:**
+    *   `lapack95` (Intel MKL): The `PolyRoots` subroutine relies on LAPACK routines (`gebal`, `hseqr`) for eigenvalue computation of the companion matrix. Therefore, linking against a LAPACK implementation (like Intel MKL, as indicated by `use lapack95`) is necessary for `PolyRoots` to function. The `Root` subroutine (Brent's method) does not have this external dependency.
+```

--- a/docs/search.md
+++ b/docs/search.md
@@ -1,0 +1,90 @@
+# search.f90 (Module: Search)
+
+## Overview
+
+The `Search` module provides utility functions for searching within data structures. Currently, it offers a binary search function for finding elements in sorted arrays.
+
+## Key Components
+
+### Functions/Subroutines
+
+*   `BinarySearch(SortedX, SortedDataArray)` (pure function): Performs a binary search for multiple elements within a sorted array.
+    *   **Purpose:** Given an array of values (`SortedX`) to search for, and a target array (`SortedDataArray`) that is sorted in ascending order, this function returns the indices in `SortedDataArray` where the elements of `SortedX` would be located.
+    *   **Parameters:**
+        *   `SortedX` (real(WP), dimension(1:), intent(in)): An array of elements to be found. The implementation assumes that this array (`SortedX`) is also sorted in ascending order for efficient processing of multiple search values, as the search for each element `SortedX(ctr)` initializes its search range based on the result of `SortedX(ctr-1)`.
+        *   `SortedDataArray` (real(WP), dimension(:), intent(in)): The array to be searched. This array **must** be sorted in ascending order for the binary search algorithm to work correctly.
+    *   **Returns:** (integer, dimension(size(SortedX))): An array of integers of the same size as `SortedX`. Each element `BinarySearch(i)` contains the index `m` in `SortedDataArray` such that `SortedDataArray(m) <= SortedX(i) < SortedDataArray(m+1)`. If `SortedX(i)` is smaller than the first element of `SortedDataArray`, the index will typically be 0 (or 1, depending on loop specifics if `m` is adjusted before assignment, needs careful check of implementation details if `SortedX(i)` is out of lower bound). If `SortedX(i)` is equal to `SortedDataArray(m)`, it returns `m`. If `SortedX(i)` is larger than all elements, it will be the index of the last element. Essentially, it finds the position where `SortedX(i)` fits or is located.
+
+### Abstract Interface `func`
+*   The `Search` module includes an `abstract interface func` definition:
+    ```fortran
+    abstract interface
+        pure function func(x) result(y)
+            import :: WP
+            implicit none
+            real(WP), intent(in) :: x !< independent variable
+            real(WP) :: y
+        end function func
+    end interface
+    ```
+    This interface appears to be unused by the `BinarySearch` function and might be a leftover from development or copied from another module (like `RootFinding`). It does not affect the functionality of `BinarySearch`.
+
+### Types/Classes
+*   Not applicable. This module does not define or export public types or classes.
+
+## Important Variables/Constants
+
+*   `MAX_ITERATIONS` (integer, parameter): A constant `MAX_ITERATIONS = 50` is defined in this module.
+    Similar to the `func` interface, this constant does not seem to be used by the `BinarySearch` function, which is based on direct array indexing rather than an iterative refinement process that would need such a limit. This might also be a leftover from development.
+
+## Usage Examples
+
+### `BinarySearch` Example
+
+```fortran
+program Test_BinarySearch
+  use Search
+  use FMUTILBase, only: WP ! For WP kind parameter
+  implicit none
+
+  real(WP), dimension(10) :: data_array = [ 1.0_WP, 3.0_WP, 5.0_WP, 7.0_WP, 9.0_WP, &
+                                           11.0_WP, 13.0_WP, 15.0_WP, 17.0_WP, 19.0_WP ]
+  real(WP), dimension(4)  :: items_to_find = [ 3.0_WP, 8.0_WP, 19.0_WP, 0.5_WP ]
+  ! Note: For optimal use as per implementation detail, items_to_find should also be sorted.
+  ! Let's sort it:
+  real(WP), dimension(4)  :: sorted_items_to_find = [ 0.5_WP, 3.0_WP, 8.0_WP, 19.0_WP ]
+
+  integer, dimension(size(sorted_items_to_find)) :: indices
+  integer :: i
+
+  print *, "Data Array:", data_array
+  print *, "Items to find (sorted):", sorted_items_to_find
+
+  indices = BinarySearch(sorted_items_to_find, data_array)
+
+  print *, "Found indices (positions):"
+  do i = 1, size(sorted_items_to_find)
+    print *, "Item ", sorted_items_to_find(i), " found at/near index ", indices(i)
+    ! Interpretation: indices(i) is the index m such that data_array(m) <= items_to_find(i)
+    ! If items_to_find(i) < data_array(1), index might be 1 (or 0 if result was adjusted, check actual output).
+    ! If items_to_find(i) == data_array(indices(i)), it's an exact match.
+    ! If data_array(indices(i)) < items_to_find(i), then items_to_find(i) would be inserted after data_array(indices(i)).
+  end do
+
+  ! Example for an unsorted items_to_find (less optimal for this specific implementation)
+  ! but still works element by element if the internal search resets properly for each item.
+  ! The current implementation's 'a = m' suggests it tries to optimize for sorted 'SortedX'.
+  ! If SortedX is not sorted, the search for SortedX(ctr) starts from where SortedX(ctr-1) was found,
+  ! which might not be efficient or correct if SortedX is not sorted.
+  ! For safety and correctness with the current code, SortedX should be sorted.
+
+end program Test_BinarySearch
+```
+
+## Dependencies and Interactions
+
+*   **Internal Dependencies:**
+    *   `FMUTILBase`: Uses the `WP` kind parameter for defining the precision of real numbers used in the search.
+*   **External Libraries:**
+    *   None. The `BinarySearch` function is implemented using standard Fortran array operations.
+```

--- a/docs/template.md
+++ b/docs/template.md
@@ -1,0 +1,46 @@
+# {{FILE_NAME}}
+
+## Overview
+
+[Provide a brief description of what the code file does and its role within the larger project.]
+
+## Key Components
+
+[List the primary functions, classes, or modules defined in the file, with a short description of each.]
+
+### Functions/Subroutines
+
+*   `{{FUNCTION_NAME}}`: [Description]
+    *   **Parameters:**
+        *   `{{PARAM_NAME}}` ({{PARAM_TYPE}}, {{INTENT}}): [Description]
+    *   **Returns:** ({{RETURN_TYPE}}) [Description, if applicable]
+
+### Types/Classes
+
+*   `{{TYPE_NAME}}`: [Description]
+    *   **Properties:**
+        *   `{{PROPERTY_NAME}}` ({{PROPERTY_TYPE}}): [Description]
+    *   **Methods:**
+        *   `{{METHOD_NAME}}`: [Description]
+
+## Important Variables/Constants
+
+*   `{{VARIABLE_NAME}}` ({{VARIABLE_TYPE}}): [Description and purpose]
+
+## Usage Examples
+
+[If applicable, provide examples or code snippets demonstrating how to use the functions, classes, or modules in the file.]
+
+```fortran
+! Example code here
+```
+
+## Dependencies and Interactions
+
+[Notes on any dependencies the file has on other parts of the system or external libraries, and how it interacts with other components.]
+
+*   **Internal Dependencies:**
+    *   [Module/File Name]: [Reason for dependency]
+*   **External Libraries:**
+    *   [Library Name]: [Reason for dependency]
+```

--- a/docs/vector.md
+++ b/docs/vector.md
@@ -1,0 +1,159 @@
+# vector.f90 (Module: Vectors)
+
+## Overview
+
+The `Vectors` module provides a dynamic vector data structure, analogous to the C++ STL `std::vector`. It is implemented using an array of "buckets," where each bucket is also an array. This structure allows for efficient element addition and access. To use the `Vector` type, users must define their own data type that extends the abstract `VecElem` type and provide an assignment subroutine for this custom type.
+
+## Key Components
+
+### Types/Classes
+
+*   `VecElem` (abstract, public): This is an abstract base type that users must extend to define the type of elements stored in a `Vector`.
+    *   **Deferred Procedure:**
+        *   `AssignVecElem(lhs, rhs)`: Users *must* implement a subroutine with this interface for their custom element type. This subroutine is responsible for defining how elements of the custom type are assigned (copied). It is then associated with the generic `assignment(=)` operator for the custom type.
+
+*   `InvalidVecElem` (public, extends `VecElem`): A concrete type that can be returned by vector operations in case of an error or exception (e.g., accessing an out-of-bounds index). It has an internal `Invalid` logical flag.
+
+*   `Vector` (public): This is the main public type representing the dynamic vector. It manages a collection of elements derived from `VecElem`.
+    *   **Public Component:**
+        *   `status` (integer): Indicates the success (0) or failure (negative value) of the last operation.
+    *   **Methods (Procedures):**
+        *   `Init(NewBktsToAllocate, BktCap, MoldElem)`: Initializes the vector. Can set the number of new buckets to allocate on expansion, the capacity of each bucket, and a mold element for allocation. If not called, the vector initializes with defaults on first data push.
+        *   `Size()`: Returns the total number of elements currently stored in the vector.
+        *   `Capacity()`: Returns the total number of elements the vector can store before needing to allocate more memory.
+        *   `NUsedBkts()`: Returns the number of internal data buckets currently in use.
+        *   `Reserve(n)`: Increases the vector's capacity to be able to hold at least `n` elements.
+        *   `ShrinkToFit()`: Deallocates unused buckets to reduce memory footprint, making capacity closer to the current size.
+        *   `PushBack(velem)`: Adds an element (`velem` of a type extending `VecElem`) to the end of the vector. Returns the 1-based index of the new element, or 0 on error.
+        *   `PopBack()`: Removes and returns the last element from the vector.
+        *   `ElemAt(Index)`: Returns a pointer to the element at the specified 1-based `Index`. The pointer is not associated if the index is invalid or the element slot is marked as free.
+        *   `Front()`: Returns a copy of the first element in the vector.
+        *   `Back()`: Returns a copy of the last element in the vector.
+        *   `Slice(lower, upper, stride)`: Returns a new array containing a copy of vector elements from `lower` to `upper` (1-based indices) with a given `stride`. This is less efficient due to copying.
+        *   `BktSlice(lower, upper)`: Returns a pointer to a contiguous array slice of elements within a single bucket. `upper` might be adjusted if the requested slice crosses bucket boundaries. More efficient as it avoids copying.
+        *   `Insert(pos, NewElems, count)`: Inserts one or more `NewElems` (repeated `count` times) at the 1-based `pos`. Existing elements are shifted. This can be inefficient.
+        *   `Erase(lower, upper)`: Deletes elements from `lower` to `upper` (inclusive). Existing elements are shifted. This can be inefficient.
+        *   `Clear()`: Removes all elements from the vector. Bucket memory is not deallocated immediately but can be by `ShrinkToFit`.
+        *   `Destroy()`: Finalizer procedure that frees all memory allocated by the vector and its buckets. Called automatically when a `Vector` variable goes out of scope.
+        *   `assignment(=)`: Overloads the assignment operator to allow copying of one `Vector` to another, creating a deep copy of elements and internal state.
+
+*   `Bkt` (private): Internal type representing a single bucket, which holds an array of `VecElem` (`BktData`) and flags for free slots (`SlotFree`).
+*   `BktPtr` (private): A type holding a pointer to a `Bkt`. `VecData` in `Vector` is an array of `BktPtr`.
+
+## Important Variables/Constants
+
+*   `DEFAULT_BKTCAP` (integer, parameter): Default capacity (3) for internal buckets when a `Vector` is initialized without a specific `BktCap`.
+*   `DEFAULT_NEWBKTSALLOCATED` (integer, parameter): Default number of new buckets (2) to allocate when the vector's capacity is exceeded and needs to grow, if not specified via `Init`.
+
+## Usage Examples
+
+To use the `Vector` type, you first need to define your own data type that extends `VecElem` and provide an assignment procedure for it.
+
+```fortran
+module MyVectorElements
+  use Vectors ! Import the Vectors module to access VecElem
+  implicit none
+
+  ! 1. Define your custom element type
+  type, extends(VecElem) :: MyIntElement
+    integer :: value
+  contains
+    procedure :: AssignVecElem => MyIntElement_Assign
+    ! You can add other type-bound procedures specific to MyIntElement here
+  end type MyIntElement
+
+  ! Interface for the assignment procedure (already defined in Vectors module)
+  ! abstract interface
+  !   subroutine assign_vecelem(lhs, rhs)
+  !     import :: VecElem
+  !     class(VecElem), intent(out) :: lhs
+  !     class(VecElem), intent(in)  :: rhs
+  !   end subroutine
+  ! end interface
+
+contains
+
+  ! 2. Implement the assignment subroutine for your custom type
+  subroutine MyIntElement_Assign(lhs, rhs)
+    class(MyIntElement), intent(out) :: lhs
+    class(VecElem), intent(in) :: rhs ! RHS must be class(VecElem) as per interface
+
+    select type (rhs)
+    class is (MyIntElement) ! Check if RHS is actually of MyIntElement type
+      lhs%value = rhs%value
+    type is (InvalidVecElem)
+      ! Handle assignment from InvalidVecElem if necessary,
+      ! or signal an error. For simplicity, we might just not assign.
+      print *, "Warning: Attempting to assign from InvalidVecElem"
+    class default
+      ! This case should ideally not happen if only MyIntElement instances
+      ! are added to a Vector of MyIntElement.
+      error stop "MyIntElement_Assign: Type mismatch."
+    end select
+  end subroutine MyIntElement_Assign
+
+end module MyVectorElements
+
+program Test_MyVector
+  use Vectors
+  use MyVectorElements ! Import your custom element module
+  implicit none
+
+  type(Vector) :: vec
+  type(MyIntElement) :: my_elem
+  class(VecElem), pointer :: p_elem
+  integer :: i, sz, cap, new_idx
+
+  ! Optional: Initialize the vector with custom parameters
+  ! call vec%Init(MoldElem=MyIntElement(0)) ! Provide a mold for allocation
+
+  ! 3. Add elements to the vector
+  my_elem%value = 10
+  new_idx = vec%PushBack(my_elem)
+  print *, "Pushed ", my_elem%value, " at index ", new_idx
+
+  my_elem%value = 20
+  new_idx = vec%PushBack(my_elem)
+  print *, "Pushed ", my_elem%value, " at index ", new_idx
+
+  my_elem%value = 30
+  new_idx = vec%PushBack(my_elem)
+  print *, "Pushed ", my_elem%value, " at index ", new_idx
+
+
+  ! Get size and capacity
+  sz = vec%Size()
+  cap = vec%Capacity()
+  print *, "Vector size:", sz       ! Output: Vector size: 3
+  print *, "Vector capacity:", cap  ! Output depends on DEFAULT_BKTCAP & DEFAULT_NEWBKTSALLOCATED
+
+  ! 4. Retrieve an element
+  p_elem => vec%ElemAt(2) ! Get pointer to element at index 2
+  if (associated(p_elem)) then
+    select type (p_elem)
+    class is (MyIntElement)
+      print *, "Element at index 2:", p_elem%value ! Output: Element at index 2: 20
+    end select
+  else
+    print *, "Element at index 2 not found or invalid."
+  end if
+
+  ! Pop an element
+  call vec%PopBack()
+  print *, "Vector size after PopBack:", vec%Size() ! Output: Vector size after PopBack: 2
+
+  ! Clear the vector
+  call vec%Clear()
+  print *, "Vector size after Clear:", vec%Size()   ! Output: Vector size after Clear: 0
+
+  ! Vector is automatically destroyed when 'vec' goes out of scope
+end program Test_MyVector
+```
+
+## Dependencies and Interactions
+
+*   **Internal Dependencies:**
+    *   `FMUTILBase`: The `Vectors` module uses `FMUTILBase`. The specific reason is not explicitly detailed in the comments of `vector.f90`, but `FMUTILBase` likely provides fundamental utilities or type definitions used by the `Vectors` module.
+*   **External Libraries:**
+    *   None explicitly mentioned or used in `vector.f90`.
+```


### PR DESCRIPTION
This commit introduces Markdown documentation for the core modules of the FMUTIL library. Separate .md files have been created for each significant Fortran source file in the `src` directory.

The new documentation files are located in the `docs/` directory and include:
- `docs/list.md`: Documentation for `src/datastructs/list.f90` (Lists module).
- `docs/vector.md`: Documentation for `src/datastructs/vector.f90` (Vectors module).
- `docs/fmutil.md`: Documentation for `src/fmutil.F90` (main FMUtil module).
- `docs/fmutil_base.md`: Documentation for `src/fmutil_base.F90` (FMUTILBase module).
- `docs/rootfinding.md`: Documentation for `src/math/rootfinding.f90` (RootFinding module).
- `docs/search.md`: Documentation for `src/math/search.f90` (Search module).

Each documentation file provides:
- An overview of the module's purpose.
- A description of key components (types, functions, subroutines).
- Information on important variables and constants.
- Usage examples in Fortran.
- Notes on dependencies and interactions.

A template file (`docs/template.md`) was also created and used to ensure consistency across the documentation.